### PR TITLE
Fix console issue

### DIFF
--- a/new-monsters-pack/Mods/kurek-creatures/mods/New-content-for-Neutral/mods/Wasps/Content/config/wasps/selfbloodlust.json
+++ b/new-monsters-pack/Mods/kurek-creatures/mods/New-content-for-Neutral/mods/Wasps/Content/config/wasps/selfbloodlust.json
@@ -52,8 +52,6 @@
 		"tower" : 0
 	},
 	 
-	"index" : 43,
-	 
 	"level" : 1,
 	 
 	"levels" : {


### PR DESCRIPTION
Seemingly selfBloodlust spell has the index of the original Bloodlust.
If there are any other indexes that I missed, comment about them in this PR section.