### PR TITLE
Fix Endurance

### DIFF
--- a/new-monsters-pack/Mods/tok/mods/more secondary/content/config/skills/endurance.json
+++ b/new-monsters-pack/Mods/tok/mods/more secondary/content/config/skills/endurance.json
@@ -9,8 +9,7 @@
 			"effects": {
 				"life": {
 					"type" : "STACK_HEALTH",
-					"valueType" : "PERCENT_TO_BASE",
-					"propagator" : "BATTLE_WIDE"
+					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
 		},
@@ -20,7 +19,7 @@
 				"medium": "skills/endurance/MediumBasic.png",
 				"large": "skills/endurance/LargeBasic.png"
 			},
-			"description": "{Basic endurance}\n\nAll your creatures from Ruins get a 5% health bonus in battle.",
+			"description": "{Basic endurance}\n\nAll your creatures get a 5% health bonus in battle.",
 			"effects": {
 				"life": {
 					"val" : 5
@@ -33,7 +32,7 @@
 				"medium": "skills/endurance/MediumAdvanced.png",
 				"large": "skills/endurance/LargeAdvanced.png"
 			},
-			"description": "{Advanced endurance}\n\nAll your creatures from Ruins get a 10% health bonus in battle.",
+			"description": "{Advanced endurance}\n\nAll your creatures get a 10% health bonus in battle.",
 			"effects": {
 				"life": {
 					"val" : 10
@@ -46,7 +45,7 @@
 				"medium": "skills/endurance/MediumExpert.png",
 				"large": "skills/endurance/LargeExpert.png"
 			},
-			"description": "{Expert endurance}\n\nAll your creatures from Ruins get a 15% health bonus.",
+			"description": "{Expert endurance}\n\nAll your creatures get a 15% health bonus.",
 			"effects": {
 				"life": {
 					"val" : 15


### PR DESCRIPTION
1. Fixes bug reported on Discord, when enemy units were affected by Endurance.
2. Fixes descriptions, since the skill works not on Ruins creatures only.