### PR TITLE
Fixed reward chances in Lurkers' bank in Kurek creatures submod

### DIFF
--- a/new-monsters-pack/Mods/kurek-creatures/mod.json
+++ b/new-monsters-pack/Mods/kurek-creatures/mod.json
@@ -5,7 +5,7 @@
 	"contact": "http://www.forum.acidcave.net/profile.php?UID=4121  or  https://discord.com/channels/298106089885401090/298110850420441094",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "2.7",
+	"version" : "2.8",
 	"modType" : "Creatures",
 	"changelog" :
 	{
@@ -21,7 +21,8 @@
 		"2.4"  : ["Added Neutral creature, dwelling and spell: Orange Dragon, Enchanted Forest, Fire ring."],
 		"2.5"  : ["Added Neutral creatures, dwelling, bank, artifacts and spells: Wasps addon."],
 		"2.6"  : ["Added neutral creatures, dwellings, bank and spell. Lurkers, Terrible Eyes and Agar's Pets."],
-		"2.7"  : ["New graphics for Wasps buildings"]
+		"2.7"  : ["New graphics for Wasps buildings"],
+		"2.8"  : ["Fix reward appear chance for Lurkers' bank Evil Lair."]
 	},
 	"chinese" : {
 		"name" : "生物模组包（Kurek）",

--- a/new-monsters-pack/Mods/kurek-creatures/mods/New-content-for-Dungeon/Mods/Lurker/content/config/lurker/evillair.json
+++ b/new-monsters-pack/Mods/kurek-creatures/mods/New-content-for-Dungeon/Mods/Lurker/content/config/lurker/evillair.json
@@ -50,7 +50,7 @@
                     },
                     {
                         "message": 34,
-                        "appearChance": { "min": 0, "max": 30 },
+                        "appearChance": { "min": 30, "max": 60 },
                         "guards": [
                             { "amount": 18, "type": "beholder" },
                             { "amount": 10, "type": "lurker" },

--- a/new-monsters-pack/mod.json
+++ b/new-monsters-pack/mod.json
@@ -1,7 +1,7 @@
 {
 	"name" : "New Monsters Pack",
 	"author" : "Various",
-	"version" : "1.3.8",
+	"version" : "1.3.9",
 	"contact" : "https://vcmi.eu/",
 	"modType" : "Creatures",
 	"compatibility" :
@@ -10,6 +10,7 @@
 	},
 	"changelog" :
     {
+		"1.3.9"   : [ "Minor fix for Lurkers' bank reward chances in Kurek creatures submod" ],
 		"1.3.8"   : [ "New graphics for Wasps buildings in Kurek creatures submod" ],
 		"1.3.7"   : [ "Updated polish translation", "Changed Sphinx name into Royal Sphinx" ],
 		"1.3.6"   : [ "Missing Dungeon content" ],


### PR DESCRIPTION
It had 2 sets of guards and rewards with 0-30 chances and next one had 60-90,
so I changed the second 0-30 to 30-60.