### PR TITLE
Fix Royal Treasury guards layout in new games

### DIFF
--- a/new-monsters-pack/Mods/lord-hawk-creatures-pack/mod.json
+++ b/new-monsters-pack/Mods/lord-hawk-creatures-pack/mod.json
@@ -3,7 +3,7 @@
 	"description" : "Creatures with dellings and banks made by Lord Hawk in one mod",
 	"author" : "Lord Hawk",
 	"contact" : "https://www.forum.acidcave.net/topic.php?TID=3579",
-	"version" : "2.1",
+	"version" : "2.1.1",
 	"modType" : "Creatures",
 	"compatibility" :
 	{
@@ -11,6 +11,7 @@
 	},
 	"changelog" : 
 	{
+		"2.1.1"     : [ "13/07/2025", "Fix in submod Man at Arms, guards layout in Royal Treasury" ],
 		"2.1"     : [ "21/12/2024", "Fixes in submod code"],
         "2.0"     : [ "20/12/2024", "Added new creature Derodyme and Squire", "Added new dwellings with sounds- Laboratory, Tower of Darkness, Military Academy and Mountain Mines", "Added new banks - Hall of fear, Royal Treasury", "Added new spell - Stun", "Graphic changes and animation speeds", "Updated Czech translation" ],
         "1.1.3"   : [ "Czech translation by George King" ],

--- a/new-monsters-pack/Mods/lord-hawk-creatures-pack/mods/Man at Arms/Content/config/Man at Arms/royalTreasury.json
+++ b/new-monsters-pack/Mods/lord-hawk-creatures-pack/mods/Man at Arms/Content/config/Man at Arms/royalTreasury.json
@@ -28,7 +28,7 @@
 				"onVisitedMessage" : 33,
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
-				"guardsLayout" : "creatureBankRuins",
+				"guardsLayout" : "creatureBankRoyalTreasury",
 				"rewards":
 				[
 					{

--- a/new-monsters-pack/Mods/lord-hawk-creatures-pack/mods/Man at Arms/mod.json
+++ b/new-monsters-pack/Mods/lord-hawk-creatures-pack/mods/Man at Arms/mod.json
@@ -3,8 +3,9 @@
 	"description" : "Mod which adds 2 new units, Squire and Man at arms including their dwellings and creature banks. Also adds new spell Stun.",
 	"author" : 	"Mod: Lord Hawk. Graphics: Alex-ander, FCst1, Andruids, Lord Hawk and zeryss.",
 	"contact" : "https://www.forum.acidcave.net/topic.php?TID=3579",
-	"version" : "1.3.1",
+	"version" : "1.3.2",
 	"changelog" : {
+			"1.3.2" : [ "13/07/2025", "Fix guards layout in Royal Treasury" ],
 			"1.3.1" : [ "21/12/2024", "Code fixes" ],
         	"1.3"   : [ "20/12/2024", "Update do vcmi-1.6 format", "graphic changes and animation speeds", "double dweling for both units", "Change to the creature bank", "Bank and dwelling sounds adding", "Stun spell mana increased from 15/11 to 16/12" ],
 			"1.2"   : [ "Added new spell Stun and changing abilities", "Added creature bank", "Changing statistics" ],
@@ -33,6 +34,20 @@
 		"config/Man at Arms/dwellings.json",
 		"config/Man at Arms/royalTreasury.json"  
 	],
+	"settings" : {
+		"combat": {
+			"layouts" : {
+				"creatureBankRoyalTreasury" : {
+					"tacticsAllowed" : false,
+					"obstaclesAllowed" : false,
+					"attackerCommander" : 86,
+					"defenderCommander" : 83,
+					"attackerUnits": [ 57, 61, 90, 93, 96, 125, 129 ],
+					"defenderUnits": [ 15, 185, 172, 2, 8, 174, 181 ]
+				}
+			}
+		}
+	},
 	"chinese" : {
 		"name" : "步兵",
 		"description" : "Mod which adds 2 new units, Squire and Man at arms including their dwellings and creature banks. Also adds new spell Stun.",

--- a/new-monsters-pack/mod.json
+++ b/new-monsters-pack/mod.json
@@ -1,7 +1,7 @@
 {
 	"name" : "New Monsters Pack",
 	"author" : "Various",
-	"version" : "1.4.0",
+	"version" : "1.4.1",
 	"contact" : "https://vcmi.eu/",
 	"modType" : "Creatures",
 	"compatibility" :
@@ -10,6 +10,7 @@
 	},
 	"changelog" :
     {
+		"1.4.1"   : [ "Fixed guards layout in Royal Treasury (Man at Arms in Lord Hawk Creatures Pack)" ],
 		"1.4.0"   : [ "Updated polish translation (Kurek creatures)" ],
 		"1.3.9"   : [ "Minor fix for Lurkers' bank reward chances in Kurek creatures submod" ],
 		"1.3.8"   : [ "New graphics for Wasps buildings in Kurek creatures submod" ],


### PR DESCRIPTION
in Lord Hawk Creatures Pack
Fixing in old saves requires the layout with old name like in HotA mod